### PR TITLE
Changes to support dependencies for Ubuntu Bionic (18.04).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ find_package(Qt5Svg REQUIRED) # Qt5
 #)
 
 include(FindPkgConfig)
-pkg_search_module(ARAVIS REQUIRED aravis-0.4 aravis-0.2)
+pkg_search_module(ARAVIS REQUIRED aravis-0.6 aravis-0.4 aravis-0.2)
 pkg_check_modules(GIO REQUIRED gio-2.0)
 pkg_check_modules(SWSCALE REQUIRED libswscale)
 pkg_check_modules(AVCODEC REQUIRED libavcodec)
@@ -89,10 +89,9 @@ set(CMAKE_REQUIRED_LIBRARIES ${AVUTIL_LDFLAGS})
 set(CMAKE_REQUIRED_INCLUDES ${AVUTIL_INCLUDE_DIRS})
 
 # check_symbol_exists(av_pix_fmt_desc_get libavutil/pixdesc.h HAVE_FMT_DESC_GET) # remove for Qt5
-
-if (HAVE_FMT_DESC_GET)
+#if (HAVE_FMT_DESC_GET)
   add_definitions(-DHAVE_FMT_DESC_GET)
-endif()
+#endif()
 if (ARAVIS_VERSION VERSION_LESS "0.3.5")
   add_definitions(-DARAVIS_OLD_BUFFER)
 endif()

--- a/src/api/qarvcamera.cpp
+++ b/src/api/qarvcamera.cpp
@@ -62,9 +62,9 @@ QArvCameraId::QArvCameraId()
 QArvCameraId::QArvCameraId(const char* id_, const char* vendor_,
                            const char* model_)
 {
-  id = strdup(id_);
-  vendor = strdup(vendor_);
-  model = strdup(model_);
+  id = strdup(id_ ? id_ : "");
+  vendor = strdup(vendor_ ? vendor_ : "Unknown");
+  model = strdup(model_ ? model_ : "Unknown");
 }
 
 QArvCameraId::QArvCameraId(const QArvCameraId& camid)

--- a/src/api/qarvdecoder.cpp
+++ b/src/api/qarvdecoder.cpp
@@ -17,6 +17,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include "decoders/graymap.h"
 #include "decoders/swscaledecoder.h"
@@ -25,9 +28,6 @@
 #include <QPluginLoader>
 #include <opencv2/imgproc/imgproc.hpp>
 #include <type_traits>
-extern "C" {
-#include <arvenums.h>
-}
 
 using namespace QArv;
 
@@ -190,14 +190,14 @@ initPluginFormats()
   return list;
 }
 
-static QMap<ArvPixelFormat, enum PixelFormat> initSwScaleFormats();
+static QMap<ArvPixelFormat, enum AVPixelFormat> initSwScaleFormats();
 
 // List of formats supported by plugins.
 static QList<QArvPixelFormat*> pluginFormats = initPluginFormats();
 
 // List of formats supported by libswscale, with mappings to
 // appropriate ffmpeg formats.
-QMap<ArvPixelFormat, enum PixelFormat> swScaleFormats = initSwScaleFormats();
+QMap<ArvPixelFormat, enum AVPixelFormat> swScaleFormats = initSwScaleFormats();
 
 QList<ArvPixelFormat>
 QArvPixelFormat::supportedFormats()
@@ -234,12 +234,12 @@ QArvDecoder::makeDecoder(QByteArray specification)
     s >> fmt >> fast;
     return QArvDecoder::makeDecoder(fmt, size, fast);
   } else if (type == "SwScale") {
-    static_assert(sizeof(PixelFormat) <= sizeof(qlonglong),
-                  "qlonglong not large enough to hold libav PixelFormat.");
+    static_assert(sizeof(AVPixelFormat) <= sizeof(qlonglong),
+                  "qlonglong not large enough to hold libav AVPixelFormat.");
     qlonglong fmt;
     int flags;
     s >> fmt >> flags;
-    return QArvDecoder::makeSwScaleDecoder((PixelFormat)fmt, size, flags);
+    return QArvDecoder::makeSwScaleDecoder((AVPixelFormat)fmt, size, flags);
   }
   return NULL;
 }
@@ -271,7 +271,7 @@ QArvDecoder::makeDecoder(ArvPixelFormat format, QSize size, bool fast)
  * Returns NULL if the format is not supported.
  */
 QArvDecoder*
-QArvDecoder::makeSwScaleDecoder(PixelFormat fmt, QSize size, int swsFlags)
+QArvDecoder::makeSwScaleDecoder(AVPixelFormat fmt, QSize size, int swsFlags)
 {
   if (swsFlags)
     return new QArv::SwScaleDecoder(size, fmt, 0, swsFlags);
@@ -279,19 +279,19 @@ QArvDecoder::makeSwScaleDecoder(PixelFormat fmt, QSize size, int swsFlags)
     return new QArv::SwScaleDecoder(size, fmt, 0);
 }
 
-static QMap<ArvPixelFormat, PixelFormat>
+static QMap<ArvPixelFormat, AVPixelFormat>
 initSwScaleFormats()
 {
-  QMap<ArvPixelFormat, PixelFormat> m;
+  QMap<ArvPixelFormat, AVPixelFormat> m;
 
-  m[ARV_PIXEL_FORMAT_YUV_422_PACKED] = PIX_FMT_UYVY422;
-  m[ARV_PIXEL_FORMAT_RGB_8_PACKED] = PIX_FMT_RGB24;
-  m[ARV_PIXEL_FORMAT_BGR_8_PACKED] = PIX_FMT_BGR24;
-  m[ARV_PIXEL_FORMAT_RGBA_8_PACKED] = PIX_FMT_RGBA;
-  m[ARV_PIXEL_FORMAT_BGRA_8_PACKED] = PIX_FMT_BGRA;
-  m[ARV_PIXEL_FORMAT_YUV_411_PACKED] = PIX_FMT_UYYVYY411;
-  m[ARV_PIXEL_FORMAT_YUV_422_PACKED] = PIX_FMT_UYVY422;
-  m[ARV_PIXEL_FORMAT_YUV_422_YUYV_PACKED] = PIX_FMT_YUYV422;
+  m[ARV_PIXEL_FORMAT_YUV_422_PACKED] = AV_PIX_FMT_UYVY422;
+  m[ARV_PIXEL_FORMAT_RGB_8_PACKED] = AV_PIX_FMT_RGB24;
+  m[ARV_PIXEL_FORMAT_BGR_8_PACKED] = AV_PIX_FMT_BGR24;
+  m[ARV_PIXEL_FORMAT_RGBA_8_PACKED] = AV_PIX_FMT_RGBA;
+  m[ARV_PIXEL_FORMAT_BGRA_8_PACKED] = AV_PIX_FMT_BGRA;
+  m[ARV_PIXEL_FORMAT_YUV_411_PACKED] = AV_PIX_FMT_UYYVYY411;
+  m[ARV_PIXEL_FORMAT_YUV_422_PACKED] = AV_PIX_FMT_UYVY422;
+  m[ARV_PIXEL_FORMAT_YUV_422_YUYV_PACKED] = AV_PIX_FMT_YUYV422;
 
   return m;
 }

--- a/src/api/qarvdecoder.h
+++ b/src/api/qarvdecoder.h
@@ -102,7 +102,7 @@ public:
 
   //! Convenience function to create a libswscale decoder, not limited to Aravis
   //! pixel formats.
-  static QArvDecoder* makeSwScaleDecoder(enum PixelFormat fmt, QSize size,
+  static QArvDecoder* makeSwScaleDecoder(enum AVPixelFormat fmt, QSize size,
                                          int swsFlags = 0);
 };
 

--- a/src/api/qarvrecordedvideo.cpp
+++ b/src/api/qarvrecordedvideo.cpp
@@ -17,14 +17,14 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvrecordedvideo.h"
 #include "globals.h"
 #include <QDir>
 #include <QFileInfo>
 #include <QSettings>
-extern "C" {
-#include <arvbuffer.h>
-}
 
 using namespace QArv;
 
@@ -34,7 +34,7 @@ QArvRecordedVideo::QArvRecordedVideo(const QString& filename)
   : fps(0)
   , uncompressed(true)
   , arvPixfmt(0)
-  , swscalePixfmt(PIX_FMT_NONE)
+  , swscalePixfmt(AV_PIX_FMT_NONE)
   , frameBytes_(0)
 {
 
@@ -76,7 +76,7 @@ QArvRecordedVideo::QArvRecordedVideo(const QString& filename)
     arvPixfmt = v.toString().toULongLong(NULL, 16);
   } else if (type == "libavutil") {
     v = s.value("libavutil_pixel_format");
-    swscalePixfmt = (enum PixelFormat)v.toLongLong();
+    swscalePixfmt = (enum AVPixelFormat)v.toLongLong();
   } else {
     logMessage() << "Unable to determine decoder type.";
     isOK = false;
@@ -149,7 +149,7 @@ QArvRecordedVideo::makeDecoder()
     return NULL;
   if (arvPixfmt != 0) {
     return QArvDecoder::makeDecoder(arvPixfmt, fsize);
-  } else if (swscalePixfmt != PIX_FMT_NONE) {
+  } else if (swscalePixfmt != AV_PIX_FMT_NONE) {
     return QArvDecoder::makeSwScaleDecoder(swscalePixfmt, fsize);
   } else {
     isOK = false;

--- a/src/api/qarvrecordedvideo.h
+++ b/src/api/qarvrecordedvideo.h
@@ -97,7 +97,7 @@ private:
   int fps;
   bool uncompressed, isOK;
   ArvPixelFormat arvPixfmt;
-  enum PixelFormat swscalePixfmt;
+  enum AVPixelFormat swscalePixfmt;
   uint frameBytes_;
 };
 

--- a/src/decoders/backup/bayer_w_cpp/bayerbg10.h
+++ b/src/decoders/backup/bayer_w_cpp/bayerbg10.h
@@ -20,12 +20,12 @@
 #ifndef BAYERBG10_H
 #define BAYERBG10_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/backup/bayer_w_cpp/bayerbg12.h
+++ b/src/decoders/backup/bayer_w_cpp/bayerbg12.h
@@ -20,12 +20,12 @@
 #ifndef BAYERBG12_H
 #define BAYERBG12_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 namespace QArv {
 

--- a/src/decoders/backup/bayer_w_cpp/bayerbg12_packed.h
+++ b/src/decoders/backup/bayer_w_cpp/bayerbg12_packed.h
@@ -20,12 +20,12 @@
 #ifndef BAYERBG12_PACKED_H
 #define BAYERBG12_PACKED_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/backup/bayer_w_cpp/bayerbg16.h
+++ b/src/decoders/backup/bayer_w_cpp/bayerbg16.h
@@ -20,12 +20,12 @@
 #ifndef BAYERBG16_H
 #define BAYERBG16_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/backup/bayer_w_cpp/bayerbg8.h
+++ b/src/decoders/backup/bayer_w_cpp/bayerbg8.h
@@ -20,12 +20,12 @@
 #ifndef BAYERBG8_H
 #define BAYERBG8_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/backup/bayer_w_cpp/bayergb10.h
+++ b/src/decoders/backup/bayer_w_cpp/bayergb10.h
@@ -20,12 +20,12 @@
 #ifndef BAYERGB10_H
 #define BAYERGB10_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/backup/bayer_w_cpp/bayergb12.h
+++ b/src/decoders/backup/bayer_w_cpp/bayergb12.h
@@ -20,12 +20,12 @@
 #ifndef BAYERGB12_H
 #define BAYERGB12_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/backup/bayer_w_cpp/bayergb12_packed.h
+++ b/src/decoders/backup/bayer_w_cpp/bayergb12_packed.h
@@ -20,12 +20,12 @@
 #ifndef BAYERGB12_PACKED_H
 #define BAYERGB12_PACKED_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/backup/bayer_w_cpp/bayergb16.h
+++ b/src/decoders/backup/bayer_w_cpp/bayergb16.h
@@ -20,12 +20,12 @@
 #ifndef BAYERGB16_H
 #define BAYERGB16_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/backup/bayer_w_cpp/bayergb8.h
+++ b/src/decoders/backup/bayer_w_cpp/bayergb8.h
@@ -20,12 +20,12 @@
 #ifndef BAYERGB8_H
 #define BAYERGB8_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/backup/bayer_w_cpp/bayergr10.h
+++ b/src/decoders/backup/bayer_w_cpp/bayergr10.h
@@ -20,12 +20,12 @@
 #ifndef BAYERGR10_H
 #define BAYERGR10_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/backup/bayer_w_cpp/bayergr12.h
+++ b/src/decoders/backup/bayer_w_cpp/bayergr12.h
@@ -20,12 +20,12 @@
 #ifndef BAYERGR12_H
 #define BAYERGR12_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/backup/bayer_w_cpp/bayergr12_packed.h
+++ b/src/decoders/backup/bayer_w_cpp/bayergr12_packed.h
@@ -20,12 +20,12 @@
 #ifndef BAYERGR12_PACKED_H
 #define BAYERGR12_PACKED_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/backup/bayer_w_cpp/bayergr16.h
+++ b/src/decoders/backup/bayer_w_cpp/bayergr16.h
@@ -20,12 +20,12 @@
 #ifndef BAYERGR16_H
 #define BAYERGR16_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/backup/bayer_w_cpp/bayergr8.h
+++ b/src/decoders/backup/bayer_w_cpp/bayergr8.h
@@ -20,12 +20,12 @@
 #ifndef BAYERGR8_H
 #define BAYERGR8_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/backup/bayer_w_cpp/bayerrg10.h
+++ b/src/decoders/backup/bayer_w_cpp/bayerrg10.h
@@ -20,12 +20,12 @@
 #ifndef BAYERRG10_H
 #define BAYERRG10_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/backup/bayer_w_cpp/bayerrg12.h
+++ b/src/decoders/backup/bayer_w_cpp/bayerrg12.h
@@ -20,12 +20,12 @@
 #ifndef BAYERRG12_H
 #define BAYERRG12_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/backup/bayer_w_cpp/bayerrg12_packed.h
+++ b/src/decoders/backup/bayer_w_cpp/bayerrg12_packed.h
@@ -20,12 +20,12 @@
 #ifndef BAYERRG12_PACKED_H
 #define BAYERRG12_PACKED_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/backup/bayer_w_cpp/bayerrg16.h
+++ b/src/decoders/backup/bayer_w_cpp/bayerrg16.h
@@ -20,12 +20,12 @@
 #ifndef BAYERRG16_H
 #define BAYERRG16_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/backup/bayer_w_cpp/bayerrg8.h
+++ b/src/decoders/backup/bayer_w_cpp/bayerrg8.h
@@ -20,12 +20,12 @@
 #ifndef BAYERRG8_H
 #define BAYERRG8_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/backup/mono_w_cpp/mono10.h
+++ b/src/decoders/backup/mono_w_cpp/mono10.h
@@ -17,10 +17,10 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "decoders/monounpacked.h"
 extern "C" {
-#include <arvenums.h>
+#include <arv.h>
 }
+#include "decoders/monounpacked.h"
 
 namespace QArv {
 

--- a/src/decoders/backup/mono_w_cpp/mono12.h
+++ b/src/decoders/backup/mono_w_cpp/mono12.h
@@ -17,10 +17,10 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "decoders/monounpacked.h"
 extern "C" {
-#include <arvenums.h>
+#include <arv.h>
 }
+#include "decoders/monounpacked.h"
 
 namespace QArv {
 

--- a/src/decoders/backup/mono_w_cpp/mono14.h
+++ b/src/decoders/backup/mono_w_cpp/mono14.h
@@ -17,10 +17,10 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "decoders/monounpacked.h"
 extern "C" {
-#include <arvenums.h>
+#include <arv.h>
 }
+#include "decoders/monounpacked.h"
 
 namespace QArv {
 

--- a/src/decoders/backup/mono_w_cpp/mono16.h
+++ b/src/decoders/backup/mono_w_cpp/mono16.h
@@ -17,10 +17,10 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "decoders/monounpacked.h"
 extern "C" {
-#include <arvenums.h>
+#include <arv.h>
 }
+#include "decoders/monounpacked.h"
 
 namespace QArv {
 

--- a/src/decoders/backup/mono_w_cpp/mono8.h
+++ b/src/decoders/backup/mono_w_cpp/mono8.h
@@ -17,10 +17,10 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "decoders/monounpacked.h"
 extern "C" {
-#include <arvenums.h>
+#include <arv.h>
 }
+#include "decoders/monounpacked.h"
 
 namespace QArv {
 

--- a/src/decoders/backup/mono_w_cpp/mono8signed.h
+++ b/src/decoders/backup/mono_w_cpp/mono8signed.h
@@ -17,10 +17,10 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "decoders/monounpacked.h"
 extern "C" {
-#include <arvenums.h>
+#include <arv.h>
 }
+#include "decoders/monounpacked.h"
 
 namespace QArv {
 

--- a/src/decoders/backup/monounpackeddecoders.h
+++ b/src/decoders/backup/monounpackeddecoders.h
@@ -20,10 +20,10 @@
 #ifndef MONOUNPACKEDDECODER_H
 #define MONOUNPACKEDDECODER_H
 
-#include "decoders/monounpacked.h"
 extern "C" {
-#include <arvenums.h>
+#include <arv.h>
 }
+#include "decoders/monounpacked.h"
 
 namespace QArv {
 

--- a/src/decoders/bayer.h
+++ b/src/decoders/bayer.h
@@ -20,12 +20,12 @@
 #ifndef BAYER_H
 #define BAYER_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 /*
 #include "decoders/bayer/bayerbg10.h"

--- a/src/decoders/bayer/bayerbg10.h
+++ b/src/decoders/bayer/bayerbg10.h
@@ -20,13 +20,13 @@
 #ifndef BAYERBG10_H
 #define BAYERBG10_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include "decoders/bayer.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/bayer/bayerbg12.h
+++ b/src/decoders/bayer/bayerbg12.h
@@ -20,13 +20,13 @@
 #ifndef BAYERBG12_H
 #define BAYERBG12_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include "decoders/bayer.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 namespace QArv {
 

--- a/src/decoders/bayer/bayerbg12_packed.h
+++ b/src/decoders/bayer/bayerbg12_packed.h
@@ -20,13 +20,13 @@
 #ifndef BAYERBG12_PACKED_H
 #define BAYERBG12_PACKED_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include "decoders/bayer.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/bayer/bayerbg16.h
+++ b/src/decoders/bayer/bayerbg16.h
@@ -20,13 +20,13 @@
 #ifndef BAYERBG16_H
 #define BAYERBG16_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include "decoders/bayer.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/bayer/bayerbg8.h
+++ b/src/decoders/bayer/bayerbg8.h
@@ -20,13 +20,13 @@
 #ifndef BAYERBG8_H
 #define BAYERBG8_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include "decoders/bayer.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/bayer/bayergb10.h
+++ b/src/decoders/bayer/bayergb10.h
@@ -20,13 +20,13 @@
 #ifndef BAYERGB10_H
 #define BAYERGB10_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include "decoders/bayer.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/bayer/bayergb12.h
+++ b/src/decoders/bayer/bayergb12.h
@@ -20,13 +20,13 @@
 #ifndef BAYERGB12_H
 #define BAYERGB12_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include "decoders/bayer.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/bayer/bayergb12_packed.h
+++ b/src/decoders/bayer/bayergb12_packed.h
@@ -20,13 +20,13 @@
 #ifndef BAYERGB12_PACKED_H
 #define BAYERGB12_PACKED_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include "decoders/bayer.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/bayer/bayergb16.h
+++ b/src/decoders/bayer/bayergb16.h
@@ -20,13 +20,13 @@
 #ifndef BAYERGB16_H
 #define BAYERGB16_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include "decoders/bayer.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/bayer/bayergb8.h
+++ b/src/decoders/bayer/bayergb8.h
@@ -20,13 +20,13 @@
 #ifndef BAYERGB8_H
 #define BAYERGB8_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include "decoders/bayer.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/bayer/bayergr10.h
+++ b/src/decoders/bayer/bayergr10.h
@@ -20,13 +20,13 @@
 #ifndef BAYERGR10_H
 #define BAYERGR10_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include "decoders/bayer.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/bayer/bayergr12.h
+++ b/src/decoders/bayer/bayergr12.h
@@ -20,13 +20,13 @@
 #ifndef BAYERGR12_H
 #define BAYERGR12_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include "decoders/bayer.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/bayer/bayergr12_packed.h
+++ b/src/decoders/bayer/bayergr12_packed.h
@@ -20,13 +20,13 @@
 #ifndef BAYERGR12_PACKED_H
 #define BAYERGR12_PACKED_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include "decoders/bayer.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/bayer/bayergr16.h
+++ b/src/decoders/bayer/bayergr16.h
@@ -20,13 +20,13 @@
 #ifndef BAYERGR16_H
 #define BAYERGR16_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include "decoders/bayer.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/bayer/bayergr8.h
+++ b/src/decoders/bayer/bayergr8.h
@@ -20,13 +20,13 @@
 #ifndef BAYERGR8_H
 #define BAYERGR8_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include "decoders/bayer.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/bayer/bayerrg10.h
+++ b/src/decoders/bayer/bayerrg10.h
@@ -20,13 +20,13 @@
 #ifndef BAYERRG10_H
 #define BAYERRG10_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include "decoders/bayer.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/bayer/bayerrg12.h
+++ b/src/decoders/bayer/bayerrg12.h
@@ -20,13 +20,13 @@
 #ifndef BAYERRG12_H
 #define BAYERRG12_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include "decoders/bayer.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/bayer/bayerrg12_packed.h
+++ b/src/decoders/bayer/bayerrg12_packed.h
@@ -20,13 +20,13 @@
 #ifndef BAYERRG12_PACKED_H
 #define BAYERRG12_PACKED_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include "decoders/bayer.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/bayer/bayerrg16.h
+++ b/src/decoders/bayer/bayerrg16.h
@@ -20,13 +20,13 @@
 #ifndef BAYERRG16_H
 #define BAYERRG16_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include "decoders/bayer.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/bayer/bayerrg8.h
+++ b/src/decoders/bayer/bayerrg8.h
@@ -20,13 +20,13 @@
 #ifndef BAYERRG8_H
 #define BAYERRG8_H
 
+extern "C" {
+#include <arv.h>
+}
 #include "api/qarvdecoder.h"
 #include "decoders/bayer.h"
 #include <QDataStream>
 #include <opencv2/imgproc/imgproc.hpp>
-extern "C" {
-#include <arvenums.h>
-}
 
 // Some formats appeared only after aravis-0.2.0, so
 // we check for their presence. The 12_PACKED formats

--- a/src/decoders/mono/mono10.h
+++ b/src/decoders/mono/mono10.h
@@ -20,10 +20,10 @@
 #ifndef MONO10_H
 #define MONO10_H
 
-#include "decoders/monounpacked.h"
 extern "C" {
-#include <arvenums.h>
+#include <arv.h>
 }
+#include "decoders/monounpacked.h"
 
 namespace QArv {
 

--- a/src/decoders/mono/mono12.h
+++ b/src/decoders/mono/mono12.h
@@ -20,10 +20,10 @@
 #ifndef MONO12_H
 #define MONO12_H
 
-#include "decoders/monounpacked.h"
 extern "C" {
-#include <arvenums.h>
+#include <arv.h>
 }
+#include "decoders/monounpacked.h"
 
 namespace QArv {
 

--- a/src/decoders/mono/mono14.h
+++ b/src/decoders/mono/mono14.h
@@ -20,10 +20,10 @@
 #ifndef MONO14_H
 #define MONO14_H
 
-#include "decoders/monounpacked.h"
 extern "C" {
-#include <arvenums.h>
+#include <arv.h>
 }
+#include "decoders/monounpacked.h"
 
 namespace QArv {
 

--- a/src/decoders/mono/mono16.h
+++ b/src/decoders/mono/mono16.h
@@ -20,10 +20,10 @@
 #ifndef MONO16_H
 #define MONO16_H
 
-#include "decoders/monounpacked.h"
 extern "C" {
-#include <arvenums.h>
+#include <arv.h>
 }
+#include "decoders/monounpacked.h"
 
 namespace QArv {
 

--- a/src/decoders/mono/mono8.h
+++ b/src/decoders/mono/mono8.h
@@ -20,10 +20,10 @@
 #ifndef MONO8_H
 #define MONO8_H
 
-#include "decoders/monounpacked.h"
 extern "C" {
-#include <arvenums.h>
+#include <arv.h>
 }
+#include "decoders/monounpacked.h"
 
 namespace QArv {
 

--- a/src/decoders/mono/mono8signed.h
+++ b/src/decoders/mono/mono8signed.h
@@ -20,10 +20,10 @@
 #ifndef MONO8SIGNED_H
 #define MONO8SIGNED_H
 
-#include "decoders/monounpacked.h"
 extern "C" {
-#include <arvenums.h>
+#include <arv.h>
 }
+#include "decoders/monounpacked.h"
 
 namespace QArv {
 

--- a/src/decoders/mono12packed.h
+++ b/src/decoders/mono12packed.h
@@ -20,10 +20,10 @@
 #ifndef MONO12PACKED_H
 #define MONO12PACKED_H
 
-#include "api/qarvdecoder.h"
 extern "C" {
-#include <arvenums.h>
+#include <arv.h>
 }
+#include "api/qarvdecoder.h"
 
 namespace QArv {
 

--- a/src/decoders/swscaledecoder.cpp
+++ b/src/decoders/swscaledecoder.cpp
@@ -30,7 +30,7 @@ extern "C" {
 
 using namespace QArv;
 
-SwScaleDecoder::SwScaleDecoder(QSize size_, PixelFormat inputPixfmt_,
+SwScaleDecoder::SwScaleDecoder(QSize size_, AVPixelFormat inputPixfmt_,
                                ArvPixelFormat arvPixFmt, int swsFlags)
   : size(size_)
   , inputPixfmt(inputPixfmt_)
@@ -55,21 +55,21 @@ SwScaleDecoder::SwScaleDecoder(QSize size_, PixelFormat inputPixfmt_,
 #endif
     if (bitsPerPixel / components > 8) {
       if (components == 1) {
-        outputPixFmt = PIX_FMT_GRAY16;
+        outputPixFmt = AV_PIX_FMT_GRAY16;
         cvMatType = CV_16UC1;
         bufferBytesPerPixel = 2;
       } else {
-        outputPixFmt = PIX_FMT_BGR48;
+        outputPixFmt = AV_PIX_FMT_BGR48;
         cvMatType = CV_16UC3;
         bufferBytesPerPixel = 6;
       }
     } else {
       if (components == 1) {
-        outputPixFmt = PIX_FMT_GRAY8;
+        outputPixFmt = AV_PIX_FMT_GRAY8;
         cvMatType = CV_8UC1;
         bufferBytesPerPixel = 1;
       } else {
-        outputPixFmt = PIX_FMT_BGR24;
+        outputPixFmt = AV_PIX_FMT_BGR24;
         cvMatType = CV_8UC3;
         bufferBytesPerPixel = 3;
       }
@@ -101,7 +101,7 @@ SwScaleDecoder::pixelFormat()
   return arvPixelFormat;
 }
 
-PixelFormat
+AVPixelFormat
 SwScaleDecoder::swscalePixelFormat()
 {
   return inputPixfmt;

--- a/src/decoders/swscaledecoder.h
+++ b/src/decoders/swscaledecoder.h
@@ -38,7 +38,7 @@ namespace QArv {
 class SwScaleDecoder : public QArvDecoder
 {
 public:
-  SwScaleDecoder(QSize size, enum PixelFormat inputPixfmt,
+  SwScaleDecoder(QSize size, enum AVPixelFormat inputPixfmt,
                  ArvPixelFormat arvPixFmt,
                  int swsFlags = SWS_FAST_BILINEAR | SWS_BITEXACT);
   virtual ~SwScaleDecoder();
@@ -47,7 +47,7 @@ public:
   int cvType();
   ArvPixelFormat pixelFormat();
   QByteArray decoderSpecification();
-  enum PixelFormat swscalePixelFormat();
+  enum AVPixelFormat swscalePixelFormat();
 
 private:
   bool OK;
@@ -57,7 +57,7 @@ private:
   int image_strides[4];
   uint8_t bufferBytesPerPixel;
   int cvMatType;
-  enum PixelFormat inputPixfmt, outputPixFmt;
+  enum AVPixelFormat inputPixfmt, outputPixFmt;
   struct AVPicture srcInfo;
   ArvPixelFormat arvPixelFormat;
   int flags;

--- a/src/decoders/unsupported.h
+++ b/src/decoders/unsupported.h
@@ -20,10 +20,10 @@
 #ifndef UNSUPPORTED_H
 #define UNSUPPORTED_H
 
-#include "api/qarvdecoder.h"
 extern "C" {
-#include <arvenums.h>
+#include <arv.h>
 }
+#include "api/qarvdecoder.h"
 
 /* This is a decoder class which can specify the required
  * ArvPixelFormat and frame size nothing else.

--- a/src/globals.h
+++ b/src/globals.h
@@ -20,6 +20,7 @@
 #ifndef GLOBALS_H
 #define GLOBALS_H
 
+#include <math.h>
 #include <QDebug>
 #include <QStandardItemModel>
 

--- a/src/qarvmainwindow.cpp
+++ b/src/qarvmainwindow.cpp
@@ -17,6 +17,10 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+extern "C" {
+#include <arv.h>
+}
+
 #include "globals.h"
 #include "qarvmainwindow.h"
 #include "api/qarvcameradelegate.h"
@@ -37,10 +41,6 @@
 #include <QToolButton>
 #include <QtConcurrent/QtConcurrentRun>
 #include <qdatetime.h>
-
-extern "C" {
-#include <arvbuffer.h>
-}
 
 Q_DECLARE_METATYPE(cv::Mat)
 

--- a/src/recorders/rawrecorders/rawdecoded16.cpp
+++ b/src/recorders/rawrecorders/rawdecoded16.cpp
@@ -58,16 +58,16 @@ public:
 
     file.open(QIODevice::WriteOnly);
     if (isOK()) {
-      enum PixelFormat fmt;
+      enum AVPixelFormat fmt;
       switch (decoder->cvType()) {
         case CV_8UC1:
         case CV_16UC1:
-          fmt = PIX_FMT_GRAY16;
+          fmt = AV_PIX_FMT_GRAY16;
           frameBytes = size.width() * size.height() * 2;
           break;
         case CV_8UC3:
         case CV_16UC3:
-          fmt = PIX_FMT_BGR48;
+          fmt = AV_PIX_FMT_BGR48;
           frameBytes = size.width() * size.height() * 6;
           break;
         default:

--- a/src/recorders/rawrecorders/rawdecoded8.cpp
+++ b/src/recorders/rawrecorders/rawdecoded8.cpp
@@ -58,16 +58,16 @@ public:
 
     file.open(QIODevice::WriteOnly);
     if (isOK()) {
-      enum PixelFormat fmt;
+      enum AVPixelFormat fmt;
       switch (decoder->cvType()) {
         case CV_8UC1:
         case CV_16UC1:
-          fmt = PIX_FMT_GRAY8;
+          fmt = AV_PIX_FMT_GRAY8;
           frameBytes = size.width() * size.height();
           break;
         case CV_8UC3:
         case CV_16UC3:
-          fmt = PIX_FMT_BGR24;
+          fmt = AV_PIX_FMT_BGR24;
           frameBytes = size.width() * size.height() * 3;
           break;
         default:

--- a/src/workthread.cpp
+++ b/src/workthread.cpp
@@ -17,16 +17,16 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+extern "C" {
+#include <arv.h>
+}
+
 #include "workthread.h"
 #include "filters/filter.h"
 #include "glhistogramwidget.h"
 #include "recorders/recorder.h"
 #include <QCoreApplication>
 #include <QThread>
-
-extern "C" {
-#include <arvbuffer.h>
-}
 
 using namespace QArv;
 


### PR DESCRIPTION
Changes to resolve a number of issues related to the newer versions of libraries available in the latest LTS release of Ubuntu Bionic (18.04) and the latest version of the Aravis libraries.  Notably, the API in FFmpeg libavutil/pixfmt.h changed with the PixelFormat type now being AVPixelFormat and the PIX_FMT_XXX constants now being AV_PIX_FMT_XXX.  Changes to the Aravis libraries now mandate that only arv.h be included rather than other related include files (arvenums.h can no longer be included).  Resolving conflicts between the Qt library and 'signals' being effectively a reserved word and 'signals' being structure members in the glib headers causing compilation errors.

With these chagnes Qarv-qt5 now properly builds against the versions of libraries on Ubuntu Bionic (18.04) and the Aravis 0.5.12 library.